### PR TITLE
fixed the workflow so images are now tagged with latest/commit id

### DIFF
--- a/.github/workflows/deploy-to-registry.yml
+++ b/.github/workflows/deploy-to-registry.yml
@@ -32,8 +32,15 @@ jobs:
         run: docker login ghcr.io -u yasir-khalid -p ${{ secrets.GHCR }}
       - name: Build & Push the image
         run: |
-          docker build . -t ghcr.io/yasir-khalid/shuttlebot:latest
+          LATEST_COMMIT_ID=$(git rev-parse --short HEAD)
+          echo "Building Image with tag:latest / tag:"${LATEST_COMMIT_ID}
+          docker build . -t ghcr.io/yasir-khalid/shuttlebot:latest -t ghcr.io/yasir-khalid/shuttlebot:${LATEST_COMMIT_ID}
           docker push ghcr.io/yasir-khalid/shuttlebot:latest
+          docker push ghcr.io/yasir-khalid/shuttlebot:${LATEST_COMMIT_ID}
+  deploy-to-cloud:
+    needs: push-to-registry
+    runs-on: ubuntu-latest
+    steps:
       - name: Trigger Webhook / Deploy to Render
         run: |
           curl -X POST https://api.render.com/deploy/srv-cm5r5bnqd2ns73eq1k8g?key=Im5XAO4qeIU

--- a/shuttlebot/backend/requests/tests/test_API_health.py
+++ b/shuttlebot/backend/requests/tests/test_API_health.py
@@ -4,15 +4,7 @@ def test_api_health():
     """Tests if API is healthy or not"""
     url = "https://better-admin.org.uk/api/activities/venues"
     headers = {
-        "authority": "better-admin.org.uk",
-        "accept": "application/json",
-        "accept-language": "en-GB,en-US;q=0.9,en;q=0.8",
         "origin": "https://bookings.better.org.uk",
-        "referer": "https://bookings.better.org.uk/",
-        "sec-fetch-dest": "empty",
-        "sec-fetch-mode": "cors",
-        "sec-fetch-site": "cross-site",
-        "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1"
     }
     response = httpx.get(url, headers=headers)
     assert response.status_code == 200, "Expected status code to be 200, but it was:"


### PR DESCRIPTION
> if a new image with image tag: latest is pushed, older can retain their commit hash