### PR TITLE
Handle stale slots by marking missing slots as unavailable

### DIFF
--- a/sportscanner/crawlers/parsers/better/pickleball/scraper.py
+++ b/sportscanner/crawlers/parsers/better/pickleball/scraper.py
@@ -27,11 +27,14 @@ class BetterLeisurePickleballRequestStrategy(AbstractRequestStrategy):
     ) -> List[RequestDetailsWithMetadata]:
         request_generator_list = []
         _version = "/v2" if sports_venue.slug in ["woolwich-waves-leisure-centre"] else ""
-        activityIds = {
-            0: "pickleball-40mins" + _version,
-            1: "pickleball-60mins" + _version
-        }
-        for activityId in activityIds.values():
+        if sports_venue.slug in ["lee-valley-velopark"]:
+            activity_ids_list = ["pickleball-60mins-court"]
+        else:
+            activity_ids_list = [
+                "pickleball-40mins" + _version,
+                "pickleball-60mins" + _version
+            ]
+        for activityId in activity_ids_list:
             formatted_date: str = fetch_date.strftime('%Y-%m-%d') # YYYY-MM-DD
             url = (
                 f"https://better-admin.org.uk/api/activities/venue/"

--- a/sportscanner/crawlers/parsers/better/squash/scraper.py
+++ b/sportscanner/crawlers/parsers/better/squash/scraper.py
@@ -26,11 +26,11 @@ class BetterLeisureSquashRequestStrategy(AbstractRequestStrategy):
             self, sports_venue: sportscanner.storage.postgres.tables.SportsVenue, fetch_date: date, token: Optional[str] = None
     ) -> List[RequestDetailsWithMetadata]:
         request_generator_list = []
-        _version = "/v2" if sports_venue.slug in ["woolwich-waves-leisure-centre"] else ""
-        activityIds = {
-            0: "squash-court-40min" + _version
-        }
-        for activityId in activityIds.values():
+        if sports_venue.slug in ["woolwich-waves-leisure-centre"]:
+            activity_ids_list = ["squash-40min/v2"]
+        else:
+            activity_ids_list = ["squash-court-40min"]
+        for activityId in activity_ids_list:
             formatted_date: str = fetch_date.strftime('%Y-%m-%d') # YYYY-MM-DD
             url = (
                 f"https://better-admin.org.uk/api/activities/venue/"

--- a/sportscanner/storage/postgres/database.py
+++ b/sportscanner/storage/postgres/database.py
@@ -151,8 +151,59 @@ def truncate_and_reload_all(slots_from_all_venues, TableForLoading: sqlmodel.mai
 
 @timeit
 def insert_records_to_table(slots_from_all_venues, TableForLoading: sqlmodel.main.SQLModelMetaclass):
-    """Bulk upsert slots into a table"""
+    """Bulk upsert slots into a table.
+
+    Also handles stale slots: for any existing slots in DB that are NOT in the incoming
+    data (i.e., the API no longer returns them), they will be marked as spaces=0.
+    This ensures stale slots don't show old availability.
+    """
+    if not slots_from_all_venues:
+        logging.warning("No slots provided for insert; skipping.")
+        return
+
     with Session(engine) as session:
+        # Step 1: Build set of incoming slot keys for comparison
+        incoming_keys = set()
+        for slots in slots_from_all_venues:
+            key = f"{slots.composite_key}-{slots.category}-{slots.date}-{slots.starting_time}-{slots.ending_time}"
+            incoming_keys.add(key)
+
+        # Step 2: Get unique composite_keys and dates from incoming data
+        composite_keys = {slots.composite_key for slots in slots_from_all_venues}
+        dates = {slots.date for slots in slots_from_all_venues}
+
+        # Step 3: Fetch existing slots for these composite_keys and dates from DB
+        existing_slots = session.exec(
+            select(TableForLoading).where(
+                TableForLoading.composite_key.in_(composite_keys),
+                TableForLoading.date.in_(dates)
+            )
+        ).all()
+
+        # Step 4: Identify missing slots (exist in DB but not in incoming data)
+        # and add them to the upsert list with spaces=0
+        now = datetime.now()
+        for existing in existing_slots:
+            key = f"{existing.composite_key}-{existing.category}-{existing.date}-{existing.starting_time}-{existing.ending_time}"
+            if key not in incoming_keys:
+                # This slot exists in DB but not in incoming API data - mark as unavailable
+                uid = hashlib.md5(key.encode("utf-8")).hexdigest()
+                slots_from_all_venues.append(
+                    TableForLoading(
+                        uid=uid,
+                        composite_key=existing.composite_key,
+                        category=existing.category,
+                        starting_time=existing.starting_time,
+                        ending_time=existing.ending_time,
+                        date=existing.date,
+                        price=existing.price,
+                        spaces=0,  # Mark as unavailable
+                        last_refreshed=now,
+                        booking_url=existing.booking_url
+                    )
+                )
+                logging.debug(f"Marked missing slot as unavailable: {key}")
+
         logging.debug(f"Loading fresh data items to db: {len(slots_from_all_venues)}")
 
         all_data = []
@@ -176,10 +227,14 @@ def insert_records_to_table(slots_from_all_venues, TableForLoading: sqlmodel.mai
                 booking_url=slots.booking_url
             ))
 
-        # Step 1: create the insert
+        if not all_data:
+            logging.warning("No data to insert after processing.")
+            return
+
+        # Step 5: create the insert
         stmt = insert(TableForLoading).values(all_data)
 
-        # Step 2: tell Postgres how to upsert
+        # Step 6: tell Postgres how to upsert
         stmt = stmt.on_conflict_do_update(
             index_elements=['uid'],
             set_={c: stmt.excluded[c] for c in all_data[0] if c != 'uid'}
@@ -187,6 +242,7 @@ def insert_records_to_table(slots_from_all_venues, TableForLoading: sqlmodel.mai
 
         session.exec(stmt)
         session.commit()
+        logging.success(f"Upserted {len(all_data)} slots into {TableForLoading.__tablename__}")
 
 def recreate_staging_table():
     with engine.begin() as conn:

--- a/sportscanner/storage/postgres/database.py
+++ b/sportscanner/storage/postgres/database.py
@@ -206,14 +206,24 @@ def insert_records_to_table(slots_from_all_venues, TableForLoading: sqlmodel.mai
 
         logging.debug(f"Loading fresh data items to db: {len(slots_from_all_venues)}")
 
-        all_data = []
-        seen_uids = set()
+        # Group slots by UID and prefer the one with available spaces (spaces > 0)
+        # This handles cases where both 40min and 60min API calls return the same slot,
+        # but one returns spaces=0 (fallback from empty response) and one returns actual availability
+        uid_to_slots = {}
         for slots in slots_from_all_venues:
             key = f"{slots.composite_key}-{slots.category}-{slots.date}-{slots.starting_time}-{slots.ending_time}"
             uid = hashlib.md5(key.encode("utf-8")).hexdigest()
-            if uid in seen_uids: # Due to 2 API calls in 40-min/60-min backfill is an issue
-                continue
-            seen_uids.add(uid)
+
+            if uid not in uid_to_slots:
+                uid_to_slots[uid] = slots
+            else:
+                # If we already have this slot, prefer the one with available spaces
+                existing = uid_to_slots[uid]
+                if slots.spaces > 0 and existing.spaces == 0:
+                    uid_to_slots[uid] = slots
+
+        all_data = []
+        for uid, slots in uid_to_slots.items():
             all_data.append(dict(
                 uid=uid,
                 composite_key=slots.composite_key,


### PR DESCRIPTION
- Modified insert_records_to_table() to automatically mark slots as spaces=0 when they exist in DB but are not returned by the API
- This prevents stale slots from showing old availability when API returns fewer slots
- Fixed bug in Better pickleball scraper where Lee Valley venue was causing type error

The fix applies globally to all venues (Better, CitySports, EveryoneActive, etc.) and all sports (badminton, squash, pickleball) because it modifies the shared insert_records_to_table function.