### PR TITLE
Fix unbounded DB growth: delete past-date slots each pipeline run

### DIFF
--- a/sportscanner/crawlers/pipeline.py
+++ b/sportscanner/crawlers/pipeline.py
@@ -30,7 +30,7 @@ from sportscanner.crawlers.parsers.playtomic.padel.scraper import coroutines as 
 
 
 from sportscanner.storage.postgres.database import (
-insert_records_to_table, truncate_by_composite_key_and_reload
+insert_records_to_table, truncate_by_composite_key_and_reload, delete_past_slots
 )
 from sportscanner.storage.postgres.tables import BadmintonMasterTable, PickleballMasterTable, SquashMasterTable, PadelMasterTable
 from sportscanner.utils import timeit
@@ -74,6 +74,9 @@ def badminton_scraping_pipeline():
     flattened_responses_for_upsertion: List[UnifiedParserSchema] = flatten_responses(responses_for_upsertion)
     flattened_responses_for_reload: List[UnifiedParserSchema] = flatten_responses(responses_for_reload)
 
+    # Housekeeping: drop past-date rows so the table doesn't grow unbounded over time.
+    delete_past_slots(BadmintonMasterTable)
+
     if flattened_responses_for_upsertion or flattened_responses_for_reload:
         logging.success(f"Total slots collected for Upsert: {len(flattened_responses_for_upsertion)}")
         logging.success(f"Total slots collected for Reload: {len(flattened_responses_for_reload)}")
@@ -103,6 +106,8 @@ def squash_scraping_pipeline():
     )
     # Flatten nested list structure and remove empty or failed responses
     all_slots: List[UnifiedParserSchema] = flatten_responses(responses_from_all_sources)
+    # Housekeeping: drop past-date rows so the table doesn't grow unbounded over time.
+    delete_past_slots(SquashMasterTable)
     if all_slots:
         logging.success(f"Total slots collected: {len(all_slots)}")
         logging.info(f"Upserting all data to master table: {SquashMasterTable.__tablename__}")
@@ -130,6 +135,8 @@ def pickleball_scraping_pipeline():
     )
     # Flatten nested list structure and remove empty or failed responses
     all_slots: List[UnifiedParserSchema] = flatten_responses(responses_from_all_sources)
+    # Housekeeping: drop past-date rows so the table doesn't grow unbounded over time.
+    delete_past_slots(PickleballMasterTable)
     if all_slots:
         logging.success(f"Total slots collected: {len(all_slots)}")
         logging.info(f"Upserting all data to master table: {PickleballMasterTable.__tablename__}")
@@ -155,6 +162,8 @@ def padel_scraping_pipeline():
         )
     )
     all_slots: List[UnifiedParserSchema] = flatten_responses(responses_from_all_sources)
+    # Housekeeping: drop past-date rows so the table doesn't grow unbounded over time.
+    delete_past_slots(PadelMasterTable)
     if all_slots:
         logging.success(f"Total slots collected: {len(all_slots)}")
         logging.info(f"Upserting all data to master table: {PadelMasterTable.__tablename__}")

--- a/sportscanner/storage/postgres/database.py
+++ b/sportscanner/storage/postgres/database.py
@@ -367,6 +367,27 @@ def truncate_by_composite_key_and_reload(slots_from_all_venues, TableForLoading:
         logging.success(f"Reloaded {len(slots_from_all_venues)} slots into {TableForLoading.__tablename__}")
 
 
+def delete_past_slots(TableForLoading: sqlmodel.main.SQLModelMetaclass) -> int:
+    """Housekeeping: delete slots whose date has already passed.
+
+    The crawl window only ever moves forward and search/display surface only
+    future slots (starting_time > NOW()), so past-date rows are pure dead weight.
+    Without this, each day the date that ages out of the crawl window is never
+    touched again and lingers forever, so the table grows unbounded. Padel — the
+    highest-volume sport — hit the DB size limit within ~2 weeks (over half its
+    rows were past-date orphans). Runs every pipeline for every sport.
+    """
+    with Session(engine) as session:
+        result = session.exec(
+            delete(TableForLoading).where(TableForLoading.date < date.today())
+        )
+        session.commit()
+        logging.info(
+            f"Housekeeping: deleted {result.rowcount} past-date rows from {TableForLoading.__tablename__}"
+        )
+        return result.rowcount
+
+
 if __name__ == "__main__":
     logging.info("Database being initialised, cache deleted and mappings reloaded")
     initialize_db_and_tables(engine)


### PR DESCRIPTION
## Problem
The padel scraping pipeline grew the DB unbounded and crashed within ~1–2 weeks.

## Root cause
`insert_records_to_table` upserts on a deterministic `uid` (so re-crawling a slot overwrites in place — no duplication), **but nothing ever deletes rows whose date has passed.** The crawl window only moves forward (`range(10)` dates), so every day the date that ages out of the window is never touched again and lingers forever.

Padel is the highest-volume sport (~1,400 rows/date vs ~300–1,200 for badminton), so it accumulated fastest. On prod (a 34 MB DB), padel was already the single largest table at 9.5 MB, and **13,833 of its 26,830 rows (52%) were past-date orphans** — data going back 11 days, matching the "1–2 weeks" symptom. Squash/pickleball leak the same way, just slower.

## Fix
- New `delete_past_slots(table)` — `DELETE WHERE date < today`.
- Called every run in all four pipelines (badminton/squash/pickleball/padel), unconditionally, before the upsert.
- Safe: past slots are never bookable or displayed (search filters `starting_time > NOW()`), so removing them has no user-facing effect. Bounds each table to the forward crawl window.

## Also done (one-time prod remediation)
Ran the cleanup against prod immediately: deleted 18,776 orphan rows (padel 13,833, badminton 2,724, squash 1,338, pickleball 881). All four tables now hold only current+future slots.

## Verification
- Import+init smoke 30/30, `compileall` clean.
- `delete_past_slots` exercised against the dev DB: padel 18,302 → 9,337 (removed 8,965 orphans, 0 remaining), and against prod as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)