### PR TITLE
Right-size crawler error logging so real failures aren't buried

### DIFF
--- a/sportscanner/crawlers/parsers/core/interfaces.py
+++ b/sportscanner/crawlers/parsers/core/interfaces.py
@@ -136,12 +136,29 @@ class BaseCrawler(ABC):
                 last_http_error = e
                 continue  # try next fallback URL variant, if any
             except Exception as e:
-                logging.error(f"Error fetching/parsing {attempt_url}: {e}")
+                # Connection-level failures (ConnectError, ReadTimeout, resets) frequently
+                # carry an empty str(e), which used to log as a blank message. Log the
+                # exception type + repr so these are actually diagnosable, and keep them at
+                # ERROR since an unreachable host is a real, actionable problem.
+                logging.error(f"Fetch failed for {attempt_url}: {type(e).__name__}: {e!r}")
                 return []
-        logging.error(
-            f"HTTP error for {request_details.url} "
-            f"(tried {len(urls_to_try)} URL variant(s)): {last_http_error}"
-        )
+        # Every URL variant returned an HTTP error status. This is an upstream response,
+        # not a crawler fault, so it shouldn't be logged at ERROR (which should mean
+        # "look at this"). Split by class:
+        #   4xx  -> expected: the venue doesn't publish this activity/duration for the
+        #           requested window (Better/GLL's canned 422 "date not within valid days").
+        #   5xx  -> upstream server error worth noticing (e.g. Better's broken pickleball v2).
+        status = last_http_error.response.status_code if last_http_error is not None else None
+        if status is not None and 400 <= status < 500:
+            logging.debug(
+                f"No data ({status}) for {request_details.url} "
+                f"(tried {len(urls_to_try)} URL variant(s)) — activity not offered for this window"
+            )
+        else:
+            logging.warning(
+                f"Upstream error ({status}) for {request_details.url} "
+                f"(tried {len(urls_to_try)} URL variant(s))"
+            )
         return []
 
     async def _create_tasks_for_item(
@@ -190,6 +207,22 @@ class BaseCrawler(ABC):
                 else:
                     successful_responses.append(response)
             flattened_responses = list(itertools.chain.from_iterable(successful_responses))
+
+            # One-line health summary per provider. A failed request returns [], so a
+            # provider coming back all-empty is the signal worth surfacing (upstream
+            # outage / IP block / withdrawn activity) rather than inferring it from a
+            # wall of per-request WARNINGs above.
+            total = len(responses)
+            with_data = sum(1 for r in successful_responses if r)
+            if total and with_data == 0:
+                logging.warning(
+                    f"{self.organisation_website}: 0/{total} requests returned data "
+                    f"— likely upstream outage, IP block, or withdrawn activity"
+                )
+            else:
+                logging.info(
+                    f"{self.organisation_website}: {with_data}/{total} requests returned data"
+                )
         return flattened_responses
 
     def ScraperCoroutines(


### PR DESCRIPTION
## What these errors actually are

Analysed the badminton/squash/pickleball crawl errors (probed the live endpoints). None are crawler bugs — but the logging made them impossible to triage:

| Error | Real cause | Fixable? |
|-------|-----------|----------|
| **CitySports** `Error fetching/parsing …: ` *(blank)* | httpx **`ConnectError('')`** — host unreachable (block/down/moved). Empty `str(e)` = blank log line. | Logging ✅ fixed; connectivity needs investigation (1 venue) |
| **Better badminton 422** (kings-hall, copper-box 60min, phoenix/gunnersbury 40min) | Body: *"The date should be within the valid days you are able to view"* on **both v1 and v2, every date** → the venue doesn't publish that activity/duration | ❌ not our bug (no data exists) |
| **Better pickleball 500** (all venues) | v1 → 422, v2 → **500 "Whoops, looks like something went wrong!"** → Better's pickleball endpoint is **broken upstream** | ❌ not fixable client-side |

## The fix (logging only — zero behaviour change)

1. **Blank messages** → log `type(e).__name__` + `repr(e)`. CitySports now reads `ConnectError: ConnectError('')` instead of nothing. Still ERROR (unreachable host is actionable).
2. **Severity matches meaning** when all URL variants HTTP-error:
   - `4xx` → **DEBUG** (expected: activity/duration not offered — Better's 422).
   - `5xx` → **WARNING** (upstream server error, e.g. Better pickleball v2 500).
3. **Per-provider health summary** in `_send_concurrent_requests`: `Better: 326/366 requests returned data`, escalated to **WARNING** at `0/N` — the one line worth alerting on (`citysport.org.uk: 0/6 … likely upstream outage, IP block, or withdrawn activity`).

## Live before/after
- Badminton **ERROR 36 → 6** (only the genuine CitySports ConnectError remains, now with a real message).
- Pickleball **ERROR 198 → 0** (upstream 500s are WARNING; one summary line flags the degradation).

## Follow-ups (not code)
- **CitySports** (1 venue) is unreachable from here too — worth checking whether the host is blocking the crawler's egress IP or the booking API moved. The new logging will make recurrences obvious.
- **Better pickleball** is an upstream outage on their side; nothing to do but wait for them to fix it. The summary line makes it visible if it persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)