### PR TITLE
Fix SQL injection, add indexes/starts_at, Valkey cache, circuit breaker, docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,61 @@
+# Architecture
+
+## System overview
+
+```mermaid
+flowchart LR
+    subgraph Providers["Booking websites"]
+        Better["Better / GLL"]
+        Others["Southwark, TowerHamlets,\nCitySports, Decathlon,\nMatchi, Playtomic, ..."]
+    end
+
+    subgraph Backend["app-crawlers (this repo)"]
+        Crawlers["Crawlers\nGitHub Actions, scheduled"]
+        DB[("PostgreSQL + PostGIS")]
+        Cache[("Valkey cache\n5 min TTL")]
+        API["FastAPI server\nRender"]
+    end
+
+    Frontend["Next.js frontend\nVercel"]
+
+    Better --> Crawlers
+    Others --> Crawlers
+    Crawlers --> DB
+    API --> DB
+    API --> Cache
+    Frontend --> API
+```
+
+Two independent processes share one database: a scheduled crawler pipeline that
+writes availability, and a FastAPI server that reads it and serves the frontend.
+Neither depends on the other being up.
+
+## Components
+
+- **Crawlers** (`sportscanner/crawlers/`). One Docker image, run on a schedule via
+  GitHub Actions, one job per sport. Fetches availability from each provider's
+  booking API, normalizes it into a shared schema, and upserts it into Postgres.
+  See [`docs/crawlers.md`](docs/crawlers.md).
+- **Database** (`sportscanner/storage/postgres/`). PostgreSQL with PostGIS, one
+  table per sport plus a venue table. See [`docs/database.md`](docs/database.md).
+- **API** (`sportscanner/api/`). FastAPI, serves search, venue lookup, health, and
+  user endpoints to the frontend. See [`docs/api.md`](docs/api.md).
+- **Cache**. Valkey, used by the API for near-static lookups (postcode geocoding,
+  venues within a radius). Optional: the API works without it, just slower.
+
+## Deployment
+
+- Crawlers: Docker image built and pushed to GHCR on merge to `main`; run via
+  GitHub Actions `workflow_dispatch`, one job per sport, triggered on a schedule by
+  an external caller.
+- API: same image, different entrypoint, deployed to Render via a webhook on image
+  push.
+- Frontend: separate repository, deployed to Vercel.
+
+## Further reading
+
+- [`docs/database.md`](docs/database.md): schema, indexing, idempotency, why
+  Postgres and not a queue.
+- [`docs/crawlers.md`](docs/crawlers.md): strategy pattern, concurrency capping,
+  retries, circuit breaker.
+- [`docs/api.md`](docs/api.md): search flow, caching, the SQL injection fixes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 **Purpose**: This file provides context for Claude Code about the Sportscanner backend repository. It documents architecture, key components, common issues, and recent fixes to help future Claude interactions understand the codebase quickly.
 
+## Documentation Style
+
+- No em dashes in any documentation (this file, `docs/`, `README.md`, `ARCHITECTURE.md`). Use a comma, a colon, or a full stop instead.
+- No emojis in documentation.
+- Keep language crisp. Document high-level architecture and design decisions, not line-by-line explanations of what code does.
+
 ## Project Overview
 Sportscanner is a court availability aggregator for racket sports (badminton, squash, pickleball) across London. It consists of:
 - **Crawlers**: Python scripts that fetch court availability from various booking websites
@@ -31,11 +37,10 @@ Sportscanner is a court availability aggregator for racket sports (badminton, sq
 
 ### 2. Database Schema (`sportscanner/storage/postgres/`)
 - **SportsVenue**: Venue metadata with geospatial `srid` column for distance queries
-- **BadmintonMasterTable**, **SquashMasterTable**, **PickleballMasterTable**: Court availability slots (production)
-- **BadmintonStagingTable**, **SquashStagingTable**, **PickleballStagingTable**: Staging tables for zero-downtime updates
+- **BadmintonMasterTable**, **SquashMasterTable**, **PickleballMasterTable**, **PadelMasterTable**: Court availability slots, written directly (no staging/swap tables exist in the current schema)
 - **Notification**, **NotificationAck**: User notifications system
 - **Critical**: `srid` column must be populated with `ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)`
-- **Table Swapping**: `swap_tables()` function swaps staging → master for zero-downtime updates
+- Writes go through `insert_records_to_table()` (upsert on `uid`, stale rows marked `spaces=0` via SQL `UPDATE`) or `truncate_by_composite_key_and_reload()` (delete + reinsert by `composite_key`, used by TowerHamlets). See `docs/database.md` for the write-path rationale.
 
 ### 3. Crawler System (`sportscanner/crawlers/parsers/`)
 Strategy pattern implementation. A provider supplies only two strategies:

--- a/README.md
+++ b/README.md
@@ -1,16 +1,29 @@
 ## Sportscanner - search and compare playing venues
 ![example workflow](https://github.com/sportscanner/app-crawlers/actions/workflows/crawler-pipeline.yml/badge.svg) ![example workflow](https://github.com/sportscanner/app-crawlers/actions/workflows/Automated-PR-tests.yml/badge.svg) ![example workflow](https://github.com/sportscanner/app-crawlers/actions/workflows/deploy-to-registry.yml/badge.svg)
 
- 
-### What is it about?
-Finding racket sports courts in London, like squash, badminton, or tennis, can be challenging, especially without an expensive club membership. While there are several "pay and play" options available, the process of finding courts and checking their availability is often frustrating. Players end up going to multiple websites/links to look up court availability near them - and thus the need for a centralised solution.
+Finding a racket sports court in London (badminton, squash, pickleball, padel)
+without an expensive club membership usually means checking several different
+booking websites by hand. Sportscanner aggregates them into one search.
 
-### System design and roadmap
-The frontend is a `Next.js` powered app that is deployed using `Vercel`, and the backend is split into 2 components: **Crawlers** are python based scripts ran using a scheduled `Github Actions` job that parses availability and stores in a centralised postgres database; and the **Sportscanner API** is a `FastAPI` based server deployed via *Render serverless cloud* and is responsible for interacting with frontend, aligning multiple venue schemas, personalisations and advanced filtering 
+### What's implemented
 
-![diagram-export-26-05-2025-21_42_35](https://github.com/user-attachments/assets/c8e2cc45-1c1d-4208-8c04-c72cd6d363d2)
+- Crawlers for Better/GLL, Southwark, Tower Hamlets, CitySports, Decathlon, Matchi,
+  Playtomic, and others, covering badminton, squash, pickleball, and padel.
+- A FastAPI backend: postcode-radius venue search, per-sport availability search
+  with time/date/consecutive-slot filtering, user accounts and favourites, personal
+  API tokens, and an MCP server for programmatic access.
+- PostgreSQL + PostGIS for storage and geospatial distance queries, with a Valkey
+  cache in front of the near-static postcode/venue lookups.
+- A per-provider circuit breaker and concurrency cap in the crawler layer, so a
+  down provider does not burn its full request budget every run.
+- A Next.js frontend (separate repository) deployed on Vercel.
 
+### Architecture
 
+Frontend (Vercel) talks to the FastAPI backend (Render), which reads from
+PostgreSQL. A separate scheduled crawler pipeline (GitHub Actions) writes to the
+same database. See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full diagram, and
+[`docs/`](docs/) for database, crawler, and API design notes.
 
 ## Authors
 - [Yasir Khalid](https://www.linkedin.com/in/yasir-khalid)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,61 @@
+# API
+
+FastAPI, deployed on Render. No `/api/v1/` prefix; routes are flat
+(`/search/{sport}`, `/venues/near`, `/health/scrapers`).
+
+## Search flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant SearchAPI as /search/{sport}
+    participant Cache as Valkey
+    participant PostcodesIO as postcodes.io
+    participant DB as Postgres
+
+    Client->>SearchAPI: POST postcode, radius, filters
+    SearchAPI->>Cache: geocode + venues-near lookup
+    alt cache hit
+        Cache-->>SearchAPI: cached venues
+    else cache miss
+        SearchAPI->>PostcodesIO: geocode postcode
+        SearchAPI->>DB: ST_DWithin venues query
+        SearchAPI->>Cache: store result (5 min TTL)
+    end
+    SearchAPI->>DB: slots WHERE composite_key, date, spaces>0, starts_at>now
+    SearchAPI-->>Client: formatted, sorted results
+```
+
+`/search/{sport}` used to call its own `/venues/near` endpoint over HTTP to resolve
+a postcode to nearby venues, an extra network hop to itself on every search request,
+for data that barely changes minute to minute. It now calls the same underlying
+function directly (`get_venues_near_postcode`), which `/venues/near` also calls; the
+route and the internal call share one implementation.
+
+## Caching: Valkey
+
+Postcode to lat/lng (via postcodes.io) and venues within a radius (a PostGIS query)
+are both near-static: the same postcode and radius combination returns the same
+answer for long stretches of time, but was being recomputed and re-queried on every
+single search. Both are now cached in Valkey (Redis-protocol-compatible) with a
+5-minute TTL.
+
+Caching is best-effort by design: if `VALKEY_URL` is not configured, or the cache is
+unreachable, every cache function degrades silently to a cache miss and the request
+falls through to postcodes.io and Postgres as before. A cache outage never turns
+into an API error.
+
+## Security: parameterized queries
+
+Two endpoints previously built SQL by interpolating request parameters directly
+into the query string:
+
+- `/health/scrapers?sports=` used the `sports` query parameter as a table name and
+  as an array literal, both unescaped.
+- `/venues/near` built a parameterized, correctly-escaped query, then discarded it
+  and ran a second, unparameterized version instead.
+
+Both are fixed. `sports` is validated against an allow-list of the four real table
+names before it can reach the query string (a table name can never be a bound SQL
+parameter, so an allow-list is the only option there); the `/venues/near` query now
+uses the parameterized version, with a fixed column name matching the actual schema.

--- a/docs/crawlers.md
+++ b/docs/crawlers.md
@@ -1,0 +1,117 @@
+# Crawlers
+
+## Architecture
+
+```mermaid
+classDiagram
+    class BaseCrawler {
+        +request_strategy
+        +response_parser_strategy
+        +organisation_website
+        _fetch_and_transform()
+        _send_concurrent_requests()
+        _auth_token()
+        _extract_content()
+        _on_empty_response()
+    }
+    class AbstractRequestStrategy {
+        +generate_request_details()
+    }
+    class AbstractResponseParserStrategy {
+        +parse()
+    }
+    class CircuitBreaker {
+        +completed
+        +failures
+        +tripped
+        +record()
+    }
+
+    BaseCrawler --> AbstractRequestStrategy : uses
+    BaseCrawler --> AbstractResponseParserStrategy : uses
+    BaseCrawler --> CircuitBreaker : tracks per run
+```
+
+A provider (Better, Southwark, TowerHamlets, and so on) supplies a request strategy
+(how to build the HTTP request for a venue and date) and a response parser (how to
+map the raw response into the unified slot schema). `BaseCrawler` owns everything
+else: the fetch loop, concurrency capping, fallback URLs, and the circuit breaker.
+This used to be a third strategy class per provider (`AbstractAsyncTaskCreationStrategy`),
+duplicated near-identically across every provider; it is now one implementation in
+`core/interfaces.py`.
+
+Two providers (Playtomic, Matchi) do not fit the per-venue request loop, since their
+APIs return all venues for a date in one call. They override `ScraperCoroutines`
+directly instead of forcing their shape through the standard strategies.
+
+## Concurrency: the semaphore
+
+Each provider crawl fires one HTTP request per (venue, activity, date) combination,
+which can be several hundred for a single pipeline run. Firing all of them in one
+burst caused a random fraction to fail with connection resets or timeouts as the
+origin server rate-limited or dropped connections under load.
+
+`CRAWLER_MAX_CONCURRENT_REQUESTS_PER_PROVIDER` (default 20) caps how many requests
+for one provider are in flight at once, via an `asyncio.Semaphore`. Requests queue
+behind the semaphore rather than firing immediately; this alone removed most of the
+transient connection failures.
+
+## Retries
+
+`httpx.AsyncHTTPTransport(retries=2)` retries connection-level failures (DNS
+blips, resets, dropped connections) transparently inside the HTTP client. It does
+not retry HTTP error status codes: a 422 or 500 is a real response from the server,
+not a transient failure, and retrying it would just repeat the same error.
+
+Separately, `fallback_urls` on a request lets a provider try a second URL if the
+first returns an HTTP error. This is used for Better/GLL's staggered v1/v2 API
+migration: a venue that has not yet migrated 422s on the v2 endpoint and must fall
+back to v1, and vice versa. This is a fallback between two different endpoints
+for the same slot, not a retry of the same request.
+
+## Circuit breaker
+
+The semaphore and retries handle transient failures. Neither one helps when a
+provider is fully down: a semaphore still schedules every one of several hundred
+queued requests, and a connection retry still retries against a host that is not
+going to answer. Without something to stop the run, a dead provider burns its full
+request budget and the pipeline's wall-clock time only to return nothing.
+
+Each `_send_concurrent_requests` run tracks a per-provider `CircuitBreaker`: after
+at least 20 requests have completed, if 50% or more of them failed (connection error
+or 5xx from the origin), the breaker trips. Any request still queued behind the
+semaphore short-circuits to an empty result instead of hitting the network, and
+requests already in flight are cancelled.
+
+A 4xx response does not count as a failure. Better/GLL returning "this venue does
+not offer this activity" for one duration is expected, per-request behaviour, not a
+signal that the provider is down; only connection-level errors and 5xx responses
+count against the breaker.
+
+The 20-request minimum sample exists so a provider with only a handful of venues
+(CitySports has 6 requests in a typical run) is never circuit-broken on a small
+sample; a real outage that empties its entire batch still shows up in the per-provider
+health summary log line, just without tripping the breaker.
+
+## Timeouts and pool sizing
+
+`HTTPX_CLIENT_TIMEOUT`, `HTTPX_CLIENT_MAX_CONNECTIONS`, and
+`HTTPX_CLIENT_MAX_KEEPALIVE_CONNECTIONS` are set per environment (`.env` for prod,
+`.dev.env` for local). Prod runs a longer timeout and a larger connection pool
+(60s, 50 connections) than local dev (15s, 5 connections), since prod crawls the
+full venue set on a schedule while dev runs are smaller, ad hoc test crawls.
+
+## Scheduling: GitHub Actions, not Kubernetes
+
+Each sport's pipeline runs as a `workflow_dispatch` GitHub Actions job (triggered on
+a schedule by an external caller), pulling the published Docker image and running
+`python sportscanner/crawlers/pipeline.py --task {sport}`. A heartbeat webhook is
+pinged after each run for dead-man's-switch monitoring.
+
+There is no Kubernetes cluster. At the current data volume (a few thousand rows
+per sport table) and request rate, there is nothing that needs pod autoscaling, a
+service mesh, or multi-node orchestration: a container that runs on a schedule and
+exits is a complete description of the workload. Running a Kubernetes control plane
+for this would be pure overhead, not a capability the system currently lacks. This
+is worth revisiting if the number of providers or the crawl frequency grows by an
+order of magnitude.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,176 @@
+# Database
+
+PostgreSQL (Aiven, managed), with PostGIS for geospatial queries.
+
+## Schema
+
+```mermaid
+erDiagram
+    SPORTSVENUE {
+        string composite_key PK
+        string organisation
+        string organisation_website
+        string venue_name
+        string slug
+        string postcode
+        string address
+        float latitude
+        float longitude
+        string_array sports
+        geometry srid
+    }
+
+    BADMINTON {
+        string uid PK
+        string composite_key FK
+        string category
+        time starting_time
+        time ending_time
+        date date
+        datetime starts_at
+        string price
+        int spaces
+        datetime last_refreshed
+        string booking_url
+    }
+
+    SQUASH {
+        string uid PK
+        string composite_key FK
+        string category
+        time starting_time
+        time ending_time
+        date date
+        datetime starts_at
+        string price
+        int spaces
+        datetime last_refreshed
+        string booking_url
+    }
+
+    PICKLEBALL {
+        string uid PK
+        string composite_key FK
+        string category
+        time starting_time
+        time ending_time
+        date date
+        datetime starts_at
+        string price
+        int spaces
+        datetime last_refreshed
+        string booking_url
+    }
+
+    PADEL {
+        string uid PK
+        string composite_key FK
+        string category
+        time starting_time
+        time ending_time
+        date date
+        datetime starts_at
+        string price
+        int spaces
+        datetime last_refreshed
+        string booking_url
+    }
+
+    SPORTSVENUE ||--o{ BADMINTON : has
+    SPORTSVENUE ||--o{ SQUASH : has
+    SPORTSVENUE ||--o{ PICKLEBALL : has
+    SPORTSVENUE ||--o{ PADEL : has
+```
+
+One table per sport rather than one polymorphic slots table. Each sport has a slightly
+different write path (Better/GLL activity durations, Southwark's non-windowed dates,
+TowerHamlets' truncate-reload) and the query shape is always "one sport, filtered by
+venue and date", so separate tables keep indexes small and queries simple, at the cost
+of four near-identical schemas.
+
+`composite_key` is an MD5 hash of `organisation_website|slug` (first 8 characters).
+It is the join key between `sportsvenue` and every slot table, and the identifier
+the frontend and API use for a venue.
+
+## Idempotency: uid as an idempotency key
+
+Every slot's `uid` is `md5(composite_key-category-date-starting_time-ending_time)`,
+a deterministic hash of the values that identify a specific bookable slot. The same
+slot crawled twice, in the same run or a week apart, always produces the same `uid`.
+
+Writes go through `INSERT ... ON CONFLICT (uid) DO UPDATE`. Re-running a crawl, retrying
+a failed pipeline, or a provider returning the same data twice in one batch (a 40-minute
+and a 60-minute API call both listing the same slot) are all safe: the same `uid` just
+gets upserted again with whatever the latest response said. There is no separate
+deduplication step outside of this key; the identifier itself carries the idempotency
+guarantee.
+
+## Marking stale slots
+
+A provider dropping a slot (booked elsewhere, activity withdrawn) is only visible as an
+absence in the next crawl, not an explicit "this slot is gone" signal. `insert_records_to_table`
+handles this in two steps per pipeline run:
+
+1. Upsert every slot in the incoming batch.
+2. `UPDATE {table} SET spaces = 0 WHERE composite_key/date match this batch AND spaces != 0
+   AND uid was not in the batch just upserted.`
+
+Step 2 runs as a single indexed `UPDATE`, not a read into Python followed by a
+reconstructed re-upsert. The previous version pulled every existing row for the
+batch's composite_keys/dates into Python, diffed it in memory against the incoming
+data, and rebuilt rows to re-upsert. That was a full round trip and object
+reconstruction on every pipeline run for no reason: the database can express
+"rows that exist but weren't just written" directly.
+
+## Housekeeping: delete_past_slots
+
+Nothing else in the write path removes rows. Without an explicit deletion step, every
+slot table grows without bound: the crawl window only ever moves forward, so a date
+that ages out of the window is written once and then never touched again.
+
+`delete_past_slots(table)` runs `DELETE WHERE date < today()` at the end of every
+pipeline run, for every sport. Past slots are never bookable and never shown (search
+filters on `starts_at > now()`), so deleting them has no user-facing effect. This is
+what actually bounds table size; the crawl logic alone does not.
+
+## starts_at
+
+`starts_at` is `date` and `starting_time` combined into a single timestamp, computed
+once at write time in `insert_records_to_table`. Before this column existed, "is this
+slot still in the future" was computed at query time as
+`to_timestamp(concat(date, ' ', starting_time), 'YYYY-MM-DD HH24:MI:SS') > now()`,
+a per-row string concatenation and parse that cannot use an index. `starts_at` is a
+plain timestamp column, so the same comparison is a direct range check.
+
+## Indexes
+
+- `(composite_key, date)` on each slot table. Every search filters
+  `composite_key IN (...) AND date == X`; this was previously unindexed (only the
+  primary key `uid` existed), forcing a full table scan on every search and on every
+  `delete_past_slots` run.
+- Partial index on `(composite_key, date) WHERE spaces > 0`. `spaces > 0` is search's
+  dominant filter (results only ever show bookable slots), so a partial index that
+  excludes unavailable rows is smaller and cheaper than indexing the whole table.
+- GiST index on `sportsvenue.srid`. `/venues/near` runs `ST_DWithin`/`ST_Distance`
+  against this column; without a spatial index this sequential-scans as venue count
+  grows.
+
+## Why Postgres, not a queue
+
+Crawling is a batch job: fetch, transform, upsert, on a schedule. There is no
+consumer that needs to react to individual slot changes as they happen, and every
+write is an idempotent upsert keyed by `uid`, not a fire-and-forget event. The read
+side (search) needs to filter and join against current state (venue, date,
+availability, distance), which is what a relational store is for. A queue would add
+a broker, consumer group management, and dead-letter handling for a workload that is
+already correctly modelled as "upsert the current state, on a schedule."
+
+## Why a 5-connection pool per process
+
+The Aiven plan caps `max_connections` at 20, with 3 reserved for the superuser role.
+The API server and the crawler pipeline are separate processes and can run at the same
+time; `pool_size=3, max_overflow=2` (5 connections per process) is a deliberate cap so
+that a few concurrent processes can coexist without exhausting the connection limit.
+This is a real ceiling, not an incidental default: scaling to more API replicas or
+running the crawler pipeline concurrently with multiple API workers needs either a
+larger Postgres plan or a connection pooler (for example PgBouncer) in front of it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ pytz==2024.1
 pandas==2.2.2
 tabulate==0.9.0
 fastmcp>=2.10.0
+redis==5.2.1

--- a/sportscanner/api/routers/health/endpoints.py
+++ b/sportscanner/api/routers/health/endpoints.py
@@ -3,8 +3,9 @@ from typing import List
 from rich import print
 from urllib.parse import urljoin
 import httpx
-from fastapi import APIRouter, Path, Query
+from fastapi import APIRouter, HTTPException, Path, Query
 from sqlmodel import text
+from starlette import status
 
 from sportscanner.storage.postgres.tables import SportsVenue
 from sportscanner.variables import *
@@ -14,23 +15,43 @@ from sportscanner.api.routers.health.schema import VenueAvailability
 
 router = APIRouter()
 
+# The sport param is interpolated as a TABLE NAME below, which can never be a bound
+# SQL parameter — so it must be validated against an allow-list before it reaches the
+# query string. This also doubles as the array-value allow-list for the `sports @>` filter.
+_SPORT_TO_TABLE = {
+    "badminton": "badminton",
+    "squash": "squash",
+    "pickleball": "pickleball",
+    "padel": "padel",
+}
 
-@router.get("/scrapers") # /venues/near?postcode=SE17TP&distance=5.0
+
+@router.get("/scrapers") # /health/scrapers?sports=badminton
 async def scrapers_healthcheck(
-    sports: Optional[str] = Query(None, description="Scraper sport category to check health for"),
+    sports: str = Query(..., description="Scraper sport category to check health for"),
 ) -> List[VenueAvailability]:
-    sport_array = f"ARRAY['{sports}']::varchar[]" if sports else "ARRAY[]::varchar[]"
-    clause: str = f"""
+    # `sports` selects a TABLE NAME below, which can never be a bound SQL parameter —
+    # it must be validated against the allow-list before it reaches the query string.
+    # (The previous unvalidated version was also broken for a missing `sports`: an
+    # f-string `FROM {sports}` with sports=None produced invalid SQL `FROM None t1`,
+    # so this was never actually optional — making it required just matches reality.)
+    if sports not in _SPORT_TO_TABLE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported sport category: {sports!r}. Must be one of {sorted(_SPORT_TO_TABLE)}",
+        )
+    table_name = _SPORT_TO_TABLE[sports]
+    clause = text(f"""
         SELECT
             t2.venue_name,
             t1.date,
             MAX(t1.last_refreshed) AS latest_refresh
         FROM
-            {sports} t1
+            {table_name} t1
         JOIN
             sportsvenue t2 ON t1.composite_key = t2.composite_key
         WHERE
-            t2.sports @> {sport_array}
+            t2.sports @> :sport_array ::varchar[]
         GROUP BY
             t1.composite_key,
             t2.venue_name,
@@ -38,12 +59,12 @@ async def scrapers_healthcheck(
         ORDER BY
             latest_refresh ASC,
             t2.venue_name;
-    """
-    
+    """).bindparams(sport_array=[sports])
+
     rows= db.get_all_rows(
-        db.engine, 
-        None, 
-        text(clause)
+        db.engine,
+        None,
+        clause
     )
     results: List[VenueDistanceModel] = [
         VenueAvailability(

--- a/sportscanner/api/routers/search/endpoints.py
+++ b/sportscanner/api/routers/search/endpoints.py
@@ -3,24 +3,20 @@ from sportscanner.logger import logging
 from datetime import date, datetime, timedelta
 from typing import List, Optional
 
-import httpx
 from fastapi import APIRouter, Header, HTTPException, Query, Request, Path
 from rich import print
-from sqlalchemy import case, func, text
-from sqlmodel import col
 from starlette import status
-from starlette.responses import JSONResponse
 
 import sportscanner.storage.postgres.database as db
 from sportscanner.storage.postgres.tables import BadmintonMasterTable, SquashMasterTable, PickleballMasterTable, PadelMasterTable
 from sportscanner.api.routers.search.schemas import SearchCriteria, SortByOptions
 from sportscanner.api.routers.users.service.userService import UserService
+from sportscanner.api.routers.venues.utils import get_venues_near_postcode
 from sportscanner.crawlers.pipeline import *
 from sportscanner.storage.postgres.dataset_transform import (
     group_slots_by_attributes,
     sort_and_format_grouped_slots_for_ui,
 )
-from sportscanner.variables import settings, urljoin
 
 router = APIRouter()
 
@@ -50,32 +46,19 @@ async def search(
     """Returns all court availability relevant to specified filters passed via payload"""
     queryTable = find_query_table(sport)
 
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.get(
-                urljoin(
-                    settings.API_BASE_URL,
-                    f"/venues/near?postcode={filters.postcode}&distance={filters.radius}",
-                )
-            )
-            json_response: List[dict] = response.json()
-        except:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Unable to fetch metadata - {filters.postcode} is not a valid UK postcode. Try changing the postcode to another one.",
-            )
+    try:
+        nearby_venues = await get_venues_near_postcode(filters.postcode, filters.radius)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unable to fetch metadata - {filters.postcode} is not a valid UK postcode. Try changing the postcode to another one.",
+        )
     if filters.analytics.specifiedVenues:
         composite_keys: List[str] = filters.analytics.specifiedVenues
     else:
-        composite_keys = [venue["composite_key"] for venue in json_response]
+        composite_keys = [venue.composite_key for venue in nearby_venues]
 
     current_timestamp = datetime.now()
-
-    datetime_expr = func.to_timestamp(
-        func.concat(queryTable.date, text("' '"),
-                    queryTable.starting_time),
-        text("'YYYY-MM-DD HH24:MI:SS'"),
-    )
 
     slots = db.get_all_rows(
         db.engine,
@@ -86,15 +69,13 @@ async def search(
         .where(queryTable.starting_time >= filters.timeRange.starting)
         .where(queryTable.ending_time <= filters.timeRange.ending)
         .where(queryTable.date == date)
-        .where(
-            datetime_expr > current_timestamp
-        ),
+        .where(queryTable.starts_at > current_timestamp),
     )
     grouped_slots = group_slots_by_attributes(
         slots, attributes=("composite_key", "date")
     )
     distance_from_venues_reference = {
-        venue["composite_key"]: venue["distance"] for venue in json_response
+        venue.composite_key: venue.distance for venue in nearby_venues
     }
     _response = sort_and_format_grouped_slots_for_ui(
         grouped_slots, distance_from_venues_reference
@@ -121,11 +102,6 @@ async def search(
     queryTable = find_query_table(sport)
 
     current_timestamp = datetime.now()
-    datetime_expr = func.to_timestamp(
-        func.concat(queryTable.date, text("' '"),
-                    queryTable.starting_time),
-        text("'YYYY-MM-DD HH24:MI:SS'"),
-    )
 
     slots = db.get_all_rows(
         db.engine,
@@ -134,9 +110,7 @@ async def search(
         .where(queryTable.composite_key == composite_key)
         .where(queryTable.spaces > 0)  # Ignore empty courts
         .where(queryTable.date == date)
-        .where(
-            datetime_expr > current_timestamp
-        ),
+        .where(queryTable.starts_at > current_timestamp),
     )
     return slots
 

--- a/sportscanner/api/routers/venues/endpoints.py
+++ b/sportscanner/api/routers/venues/endpoints.py
@@ -2,13 +2,12 @@ from datetime import datetime
 from typing import List
 from rich import print
 from urllib.parse import urljoin
-import httpx
-from fastapi import APIRouter, Path, Query
-from sqlmodel import text
+from fastapi import APIRouter, HTTPException, Path, Query
+from starlette import status
 
 from sportscanner.api.routers.geolocation.schemas import PostcodesResponseModel
 from sportscanner.api.routers.geolocation.utils import *
-from sportscanner.api.routers.venues.utils import build_geodistance_text_clause, get_venues_from_database, get_venue_by_composite_key
+from sportscanner.api.routers.venues.utils import get_venues_near_postcode, get_venues_from_database, get_venue_by_composite_key
 from sportscanner.storage.postgres.tables import SportsVenue
 from sportscanner.variables import *
 from sportscanner.api.routers.core.schemas import *
@@ -67,70 +66,10 @@ async def venues_near_postcode_and_radius(
     ),
 ) -> List[VenueDistanceModel]:
     """Get metadata associated with postcode"""
-    async with httpx.AsyncClient() as client:
-        geolocation_api_url = f"https://api.postcodes.io/postcodes/{postcode}"
-        logging.info("Requesting:", geolocation_api_url)
-        response = await client.get(geolocation_api_url)
-    
-    search_postcode_metadata: PostcodeAPIResponse = PostcodeAPIResponse(
-        **response.json()
-    )
-
-    clause = build_geodistance_text_clause(
-        search_postcode_metadata.result.longitude,
-        search_postcode_metadata.result.latitude,
-        miles=distance
-    ).params(
-        lon=search_postcode_metadata.result.longitude,
-        lat=search_postcode_metadata.result.latitude,
-        meters=distance * 1609.34
-    )
-
-    clause: str = f"""
-        SELECT
-            composite_key,
-            venue_name,
-            ROUND((ST_Distance(
-                srid,
-                ST_SetSRID(ST_MakePoint({search_postcode_metadata.result.longitude}, {search_postcode_metadata.result.latitude}), 4326)::geography
-            ) / 1609.344)::numeric, 1) AS distance_miles,
-            address,
-            sports,
-            latitude,
-            longitude
-        FROM
-            sportsvenue
-        WHERE
-            ST_DWithin(
-                srid,
-                ST_SetSRID(ST_MakePoint({search_postcode_metadata.result.longitude}, {search_postcode_metadata.result.latitude}), 4326)::geography,
-                {distance} * 1609.344
-            )
-        ORDER BY
-            ST_Distance(
-                srid,
-                ST_SetSRID(ST_MakePoint({search_postcode_metadata.result.longitude}, {search_postcode_metadata.result.latitude}), 4326)::geography
-            )
-        """
-    
-    rows= db.get_all_rows(
-        db.engine, 
-        SportsVenue, 
-        text(clause)
-    )
-    results: List[VenueDistanceModel] = [
-        VenueDistanceModel(
-            composite_key=row.composite_key,
-            venue_name=row.venue_name,
-            distance=row.distance_miles,
-            address=row.address,
-            sports=row.sports,
-            latitude=row.latitude,
-            longitude=row.longitude,
-        )
-        for row in rows
-    ]
-    return results
+    try:
+        return await get_venues_near_postcode(postcode, distance)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.get("/{composite_key}") # /venues/{composite}

--- a/sportscanner/api/routers/venues/utils.py
+++ b/sportscanner/api/routers/venues/utils.py
@@ -1,18 +1,21 @@
 import json
+import re
 from typing import Annotated, List, Literal, Optional
 
+import httpx
 from sportscanner.logger import logging
 from pydantic import Field, ValidationError
 
 import sportscanner.storage.postgres.database as db
 from sportscanner.storage.postgres.tables import SportsVenue
 from sportscanner import config
+from sportscanner.cache import cache_get_json, cache_set_json
 from enum import Enum
 from typing import Tuple
 from pydantic import BaseModel
 from sportscanner.api.routers.geolocation.utils import *
 from dataclasses import dataclass
-from sqlalchemy import text, bindparam
+from sqlalchemy import text
 from typing import Optional, Sequence
 from sportscanner.api.routers.core.schemas import *
 
@@ -74,52 +77,83 @@ def get_sports_venues_within_radius(
     return venues_within_defined_radius
 
 
-def build_geodistance_text_clause(
-    longitude: float,
-    latitude: float,
-    miles: float = 5.0,
-    table_name: str = "sportsvenue",
-) -> text:
-    """Builds a parameterized SQL TextClause that finds venues within `miles` miles of a point.
+def _normalize_postcode_for_cache_key(postcode: str) -> str:
+    return re.sub(r"\s+", "", postcode).upper()
 
-    Returns a SQLAlchemy TextClause with bound parameters (lon, lat, meters, limit) so it can be
-    passed to `get_all_rows(engine, SportsVenue, expression)` directly.
 
-    Example usage:
-        clause = build_geodistance_text_clause(-0.03837, 51.502283, miles=5.0, limit=10)
-        rows = get_all_rows(engine, SportsVenue, clause)
+async def geocode_postcode(postcode: str) -> "PostcodeAPIResponse":
+    """Resolve a UK postcode to lat/lng via postcodes.io, cached (near-static data)."""
+    cache_key = f"geocode:{_normalize_postcode_for_cache_key(postcode)}"
+    cached = cache_get_json(cache_key)
+    if cached is not None:
+        return PostcodeAPIResponse(**cached)
 
-    Notes:
-        - This assumes your table has a `geog_point` geography column (PostGIS) and a `venue_name` column.
-        - The function precomputes meters = miles * 1609.344 and binds it as a parameter.
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"https://api.postcodes.io/postcodes/{postcode}")
+    payload = response.json()
+    result = PostcodeAPIResponse(**payload)
+    cache_set_json(cache_key, payload)
+    return result
+
+
+async def get_venues_near_postcode(postcode: str, distance: float = 10.0) -> List[VenueDistanceModel]:
+    """Venues within `distance` miles of `postcode`. Both the geocode lookup and the
+    resulting venue list are cached (short TTL) since this is near-static data re-queried
+    on every search. Used directly by both GET /venues/near and POST /search/{sport} —
+    search calls this in-process rather than looping back over HTTP to its own API.
     """
+    venues_cache_key = f"venues_near:{_normalize_postcode_for_cache_key(postcode)}:{distance}"
+    cached = cache_get_json(venues_cache_key)
+    if cached is not None:
+        return [VenueDistanceModel(**row) for row in cached]
 
-    meters = float(miles) * 1609.344
+    geocoded = await geocode_postcode(postcode)
+    if geocoded.result is None:
+        raise ValueError(f"{postcode!r} is not a valid UK postcode")
+    longitude, latitude = geocoded.result.longitude, geocoded.result.latitude
 
-    sql = f"""
-    SELECT
-        venue_name,
-        ST_Distance(
-            geog_point,
-            ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography
-        ) / 1609.344 AS distance_miles
-    FROM
-        {table_name}
-    WHERE
-        ST_DWithin(
-            geog_point,
-            ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography,
-            :meters
-        )
-    ORDER BY
-        distance_miles
-    """
-
-    clause = text(sql).bindparams(
-        bindparam("lon", type_=float),
-        bindparam("lat", type_=float),
-        bindparam("meters", type_=float),
+    clause = text("""
+        SELECT
+            composite_key,
+            venue_name,
+            ROUND((ST_Distance(
+                srid,
+                ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography
+            ) / 1609.344)::numeric, 1) AS distance_miles,
+            address,
+            sports,
+            latitude,
+            longitude
+        FROM
+            sportsvenue
+        WHERE
+            ST_DWithin(
+                srid,
+                ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography,
+                :meters
+            )
+        ORDER BY
+            ST_Distance(
+                srid,
+                ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography
+            )
+    """).bindparams(
+        lon=longitude,
+        lat=latitude,
+        meters=distance * 1609.344,
     )
-
-    # attach actual parameter values so calling code can pass clause directly to session.exec
-    return clause
+    rows = db.get_all_rows(db.engine, SportsVenue, clause)
+    results = [
+        VenueDistanceModel(
+            composite_key=row.composite_key,
+            venue_name=row.venue_name,
+            distance=row.distance_miles,
+            address=row.address,
+            sports=row.sports,
+            latitude=row.latitude,
+            longitude=row.longitude,
+        )
+        for row in rows
+    ]
+    cache_set_json(venues_cache_key, [r.model_dump() for r in results])
+    return results

--- a/sportscanner/cache.py
+++ b/sportscanner/cache.py
@@ -1,0 +1,69 @@
+"""Thin best-effort cache wrapper around Valkey (Redis-protocol-compatible).
+
+Caching is optional and must never break a request: if VALKEY_URL isn't
+configured, or the cache is unreachable, every function here degrades to a
+silent no-op (cache miss) so callers always fall through to the real data
+source. TTL is short (see settings.CACHE_TTL_SECONDS) because the cached data
+(postcode geocoding, venues-within-radius) is near-static but not immutable —
+new venues can be added at any time.
+"""
+import json
+from typing import Any, Optional
+
+from sportscanner.logger import logging
+from sportscanner.variables import settings
+
+_client = None
+_client_init_attempted = False
+
+
+def _get_client():
+    """Lazily create a single Valkey client for the process. Returns None if
+    unconfigured or unreachable — callers must treat that as a cache miss."""
+    global _client, _client_init_attempted
+    if _client_init_attempted:
+        return _client
+    _client_init_attempted = True
+
+    if not settings.VALKEY_URL:
+        logging.debug("VALKEY_URL not configured — caching disabled")
+        return None
+
+    try:
+        import redis
+        _client = redis.from_url(
+            settings.VALKEY_URL,
+            socket_timeout=2,
+            socket_connect_timeout=2,
+            decode_responses=True,
+        )
+        _client.ping()
+        logging.info("Connected to Valkey cache")
+    except Exception as e:
+        logging.warning(f"Valkey cache unavailable, continuing without caching: {e}")
+        _client = None
+    return _client
+
+
+def cache_get_json(key: str) -> Optional[Any]:
+    """Returns the cached value for `key`, or None on a miss/any cache failure."""
+    client = _get_client()
+    if client is None:
+        return None
+    try:
+        raw = client.get(key)
+        return json.loads(raw) if raw is not None else None
+    except Exception as e:
+        logging.warning(f"Cache GET failed for key={key}: {e}")
+        return None
+
+
+def cache_set_json(key: str, value: Any, ttl_seconds: Optional[int] = None) -> None:
+    """Best-effort cache write. Never raises — a failed write just means no caching."""
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.set(key, json.dumps(value), ex=ttl_seconds or settings.CACHE_TTL_SECONDS)
+    except Exception as e:
+        logging.warning(f"Cache SET failed for key={key}: {e}")

--- a/sportscanner/crawlers/parsers/core/interfaces.py
+++ b/sportscanner/crawlers/parsers/core/interfaces.py
@@ -28,6 +28,40 @@ from sportscanner.variables import settings
 SportsVenue = sportscanner.storage.postgres.tables.SportsVenue
 
 
+class _CircuitBreaker:
+    """Tracks failure rate for one provider within a single _send_concurrent_requests
+    run. Once at least `min_sample` requests have completed and the failure rate is
+    at or above `failure_rate_threshold`, it trips: remaining not-yet-started requests
+    short-circuit to an empty result instead of hitting the network, and in-flight
+    ones are cancelled. Stops a dead/blocked provider from burning its full request
+    budget (and wall-clock time) once it is already clear the provider is down, rather
+    than firing every remaining request only to get empty or failed responses.
+
+    "Failure" here means a connection-level error or a 5xx from the origin - both
+    signal something is wrong with the provider itself. A 4xx (venue doesn't publish
+    this activity/duration) is not counted; that is expected, per-request behaviour,
+    not a provider health signal.
+    """
+
+    def __init__(self, min_sample: int = 20, failure_rate_threshold: float = 0.5):
+        self.min_sample = min_sample
+        self.failure_rate_threshold = failure_rate_threshold
+        self.completed = 0
+        self.failures = 0
+        self.tripped = False
+
+    def record(self, failed: bool) -> None:
+        self.completed += 1
+        if failed:
+            self.failures += 1
+        if (
+            not self.tripped
+            and self.completed >= self.min_sample
+            and (self.failures / self.completed) >= self.failure_rate_threshold
+        ):
+            self.tripped = True
+
+
 # Strategy Interfaces
 class AbstractRequestStrategy(ABC):
     """
@@ -80,6 +114,10 @@ class BaseCrawler(ABC):
         self.request_strategy = request_strategy
         self.response_parser_strategy = response_parser_strategy
         self.organisation_website = organisation_website
+        # Set fresh at the start of each _send_concurrent_requests call (a new
+        # BaseCrawler subclass instance is created per pipeline run, so this never
+        # carries state across runs).
+        self._circuit_breaker: Optional[_CircuitBreaker] = None
 
     # ------------------------------------------------------------------ hooks
     def _auth_token(self) -> Optional[str]:
@@ -113,7 +151,15 @@ class BaseCrawler(ABC):
         tried in order only if the previous variant returned an HTTP error status
         (e.g. Better/GLL 422-ing a not-yet-migrated v1 or v2 endpoint). Transient
         connection-level failures are already retried inside the httpx client.
+
+        Records each outcome against `self._circuit_breaker` (connection errors and
+        5xx count as failures; 4xx and genuine successes/empty-responses do not) —
+        see `_CircuitBreaker` and `_send_concurrent_requests`.
         """
+        breaker = self._circuit_breaker
+        if breaker is not None and breaker.tripped:
+            return []
+
         urls_to_try = [request_details.url] + (request_details.fallback_urls or [])
         last_http_error: Optional[httpx.HTTPStatusError] = None
         for attempt_url in urls_to_try:
@@ -124,6 +170,8 @@ class BaseCrawler(ABC):
                 validated_response = validate_api_response(response, content_type, attempt_url)
                 content = self._extract_content(validated_response)
                 if self._is_empty_content(content):
+                    if breaker is not None:
+                        breaker.record(failed=False)
                     return self._on_empty_response(request_details)
                 raw_data_obj = RawResponseData(
                     content=content,
@@ -131,6 +179,8 @@ class BaseCrawler(ABC):
                     headers=dict(response.headers),
                     requestMetadata=request_details,
                 )
+                if breaker is not None:
+                    breaker.record(failed=False)
                 return parser.parse(raw_data_obj)
             except httpx.HTTPStatusError as e:
                 last_http_error = e
@@ -141,15 +191,22 @@ class BaseCrawler(ABC):
                 # exception type + repr so these are actually diagnosable, and keep them at
                 # ERROR since an unreachable host is a real, actionable problem.
                 logging.error(f"Fetch failed for {attempt_url}: {type(e).__name__}: {e!r}")
+                if breaker is not None:
+                    breaker.record(failed=True)
                 return []
         # Every URL variant returned an HTTP error status. This is an upstream response,
         # not a crawler fault, so it shouldn't be logged at ERROR (which should mean
         # "look at this"). Split by class:
         #   4xx  -> expected: the venue doesn't publish this activity/duration for the
         #           requested window (Better/GLL's canned 422 "date not within valid days").
+        #           Not a provider health signal - doesn't count against the circuit breaker.
         #   5xx  -> upstream server error worth noticing (e.g. Better's broken pickleball v2).
+        #           Does count against the circuit breaker.
         status = last_http_error.response.status_code if last_http_error is not None else None
-        if status is not None and 400 <= status < 500:
+        is_client_error = status is not None and 400 <= status < 500
+        if breaker is not None:
+            breaker.record(failed=not is_client_error)
+        if is_client_error:
             logging.debug(
                 f"No data ({status}) for {request_details.url} "
                 f"(tried {len(urls_to_try)} URL variant(s)) — activity not offered for this window"
@@ -184,12 +241,21 @@ class BaseCrawler(ABC):
         # random fraction to get connection-reset/timed-out by the origin. Cap how many
         # of this provider's requests are in flight at once to smooth that out.
         semaphore = asyncio.Semaphore(settings.CRAWLER_MAX_CONCURRENT_REQUESTS_PER_PROVIDER)
+        self._circuit_breaker = _CircuitBreaker()
 
         async def _bounded(
                 task: Coroutine[Any, Any, List[UnifiedParserSchema]]
         ) -> List[UnifiedParserSchema]:
-            async with semaphore:
-                return await task
+            try:
+                async with semaphore:
+                    return await task
+            except asyncio.CancelledError:
+                # If cancelled while still queued on the semaphore (circuit breaker
+                # tripped before this task got its turn), `task` was never started —
+                # close it explicitly so Python doesn't warn about an abandoned
+                # never-awaited coroutine. A no-op if `task` already ran/finished.
+                task.close()
+                raise
 
         async with httpxAsyncClient() as client:
             for sports_venue, fetch_date in parameter_sets:
@@ -199,22 +265,49 @@ class BaseCrawler(ABC):
             logging.info(
                 f"Total number of concurrent request tasks for {self.organisation_website} : {len(all_tasks)}"
             )
-            responses = await asyncio.gather(*(_bounded(task) for task in all_tasks))
-            successful_responses = []
-            for idx, response in enumerate(responses):
-                if isinstance(response, Exception):
-                    logging.error(f"Task {idx} failed with error: {response}")
-                else:
-                    successful_responses.append(response)
+
+            # Tracked as real asyncio.Task objects (not bare coroutines) so that if the
+            # circuit breaker trips partway through, the remaining not-yet-completed
+            # tasks can be cancelled outright instead of left to run to completion.
+            pending = {asyncio.ensure_future(_bounded(task)) for task in all_tasks}
+            successful_responses: List[List[UnifiedParserSchema]] = []
+            completed_count = 0
+            breaker_tripped_at: Optional[int] = None
+            while pending:
+                done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+                for fut in done:
+                    completed_count += 1
+                    exc = fut.exception()
+                    if exc is not None:
+                        logging.error(f"Task {completed_count} failed with error: {exc}")
+                    else:
+                        successful_responses.append(fut.result())
+                if self._circuit_breaker.tripped and pending:
+                    breaker_tripped_at = completed_count
+                    logging.warning(
+                        f"{self.organisation_website}: circuit breaker tripped "
+                        f"({self._circuit_breaker.failures}/{self._circuit_breaker.completed} requests failed) "
+                        f"— cancelling {len(pending)} remaining request(s) instead of burning the full budget"
+                    )
+                    for fut in pending:
+                        fut.cancel()
+                    await asyncio.gather(*pending, return_exceptions=True)
+                    break
+
             flattened_responses = list(itertools.chain.from_iterable(successful_responses))
 
             # One-line health summary per provider. A failed request returns [], so a
             # provider coming back all-empty is the signal worth surfacing (upstream
-            # outage / IP block / withdrawn activity) rather than inferring it from a
+            # outage / IP block, or withdrawn activity) rather than inferring it from a
             # wall of per-request WARNINGs above.
-            total = len(responses)
+            total = len(all_tasks)
             with_data = sum(1 for r in successful_responses if r)
-            if total and with_data == 0:
+            if breaker_tripped_at is not None:
+                logging.warning(
+                    f"{self.organisation_website}: {with_data}/{total} requests returned data "
+                    f"(stopped early after {breaker_tripped_at} via circuit breaker)"
+                )
+            elif total and with_data == 0:
                 logging.warning(
                     f"{self.organisation_website}: 0/{total} requests returned data "
                     f"— likely upstream outage, IP block, or withdrawn activity"

--- a/sportscanner/crawlers/parsers/core/interfaces.py
+++ b/sportscanner/crawlers/parsers/core/interfaces.py
@@ -162,6 +162,17 @@ class BaseCrawler(ABC):
 
         urls_to_try = [request_details.url] + (request_details.fallback_urls or [])
         last_http_error: Optional[httpx.HTTPStatusError] = None
+        # True if ANY attempted variant returned a 4xx, not just the last one tried.
+        # Pickleball's fallback order is v1 (primary) then v2 (fallback), and v2 is a
+        # known-broken endpoint that always 500s - so a request where v1 correctly
+        # 422s "this venue doesn't offer this duration" (expected, no data) always
+        # ends the loop on v2's 500 (the last error tried). Classifying by "last error
+        # only" would treat every such request as an infra failure, even though we
+        # already got a definitive, coherent "no data" answer from v1. A 4xx anywhere
+        # in the chain means some server understood the request and had an answer;
+        # only count this as a provider-health failure if every attempt was a genuine
+        # server error or connection failure.
+        saw_client_error = False
         for attempt_url in urls_to_try:
             try:
                 response = await client.get(attempt_url, headers=request_details.headers)
@@ -184,6 +195,8 @@ class BaseCrawler(ABC):
                 return parser.parse(raw_data_obj)
             except httpx.HTTPStatusError as e:
                 last_http_error = e
+                if 400 <= e.response.status_code < 500:
+                    saw_client_error = True
                 continue  # try next fallback URL variant, if any
             except Exception as e:
                 # Connection-level failures (ConnectError, ReadTimeout, resets) frequently
@@ -197,16 +210,17 @@ class BaseCrawler(ABC):
         # Every URL variant returned an HTTP error status. This is an upstream response,
         # not a crawler fault, so it shouldn't be logged at ERROR (which should mean
         # "look at this"). Split by class:
-        #   4xx  -> expected: the venue doesn't publish this activity/duration for the
-        #           requested window (Better/GLL's canned 422 "date not within valid days").
-        #           Not a provider health signal - doesn't count against the circuit breaker.
-        #   5xx  -> upstream server error worth noticing (e.g. Better's broken pickleball v2).
-        #           Does count against the circuit breaker.
+        #   any 4xx seen -> expected: some server gave a coherent "no data" answer, e.g.
+        #           the venue doesn't publish this activity/duration for the requested
+        #           window (Better/GLL's canned 422 "date not within valid days").
+        #           Not a provider health signal - doesn't count against the circuit breaker,
+        #           even if a later fallback attempt happened to 500.
+        #   all 5xx / no 4xx anywhere -> upstream server error worth noticing (e.g.
+        #           Better's broken pickleball v2). Does count against the circuit breaker.
         status = last_http_error.response.status_code if last_http_error is not None else None
-        is_client_error = status is not None and 400 <= status < 500
         if breaker is not None:
-            breaker.record(failed=not is_client_error)
-        if is_client_error:
+            breaker.record(failed=not saw_client_error)
+        if saw_client_error:
             logging.debug(
                 f"No data ({status}) for {request_details.url} "
                 f"(tried {len(urls_to_try)} URL variant(s)) — activity not offered for this window"

--- a/sportscanner/storage/postgres/database.py
+++ b/sportscanner/storage/postgres/database.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 import sqlmodel
 from sportscanner.logger import logging
-from sqlalchemy import Engine, text, func
+from sqlalchemy import Engine, text, func, update
 from sqlalchemy.dialects.postgresql import insert
 import hashlib
 
@@ -168,103 +168,80 @@ def insert_records_to_table(slots_from_all_venues, TableForLoading: sqlmodel.mai
     Also handles stale slots: for any existing slots in DB that are NOT in the incoming
     data (i.e., the API no longer returns them), they will be marked as spaces=0.
     This ensures stale slots don't show old availability.
+
+    Previously this read every existing row for the incoming composite_keys/dates into
+    Python, diffed it against the incoming batch, and re-upserted the stale ones — an
+    app-side read-modify-write on every pipeline run. Marking stale slots is now a
+    single indexed UPDATE (WHERE composite_key/date match AND uid wasn't refreshed),
+    so nothing is read back from the DB at all.
     """
     if not slots_from_all_venues:
         logging.warning("No slots provided for insert; skipping.")
         return
 
+    now = datetime.now()
+
+    # De-dup the incoming batch by uid, preferring the entry with spaces > 0. This
+    # handles cases where both 40min and 60min API calls return the same slot, but one
+    # returns spaces=0 (fallback from an empty response) and one returns real availability.
+    uid_to_slots = {}
+    for slots in slots_from_all_venues:
+        key = f"{slots.composite_key}-{slots.category}-{slots.date}-{slots.starting_time}-{slots.ending_time}"
+        uid = hashlib.md5(key.encode("utf-8")).hexdigest()
+        existing = uid_to_slots.get(uid)
+        if existing is None or (slots.spaces > 0 and existing.spaces == 0):
+            uid_to_slots[uid] = slots
+
+    all_data = []
+    for uid, slots in uid_to_slots.items():
+        all_data.append(dict(
+            uid=uid,
+            composite_key=slots.composite_key,
+            category=slots.category,
+            starting_time=slots.starting_time,
+            ending_time=slots.ending_time,
+            date=slots.date,
+            price=slots.price,
+            spaces=slots.spaces,
+            last_refreshed=slots.last_refreshed,
+            booking_url=slots.booking_url,
+            starts_at=datetime.combine(slots.date, slots.starting_time),
+        ))
+
+    if not all_data:
+        logging.warning("No data to insert after processing.")
+        return
+
+    composite_keys = {slots.composite_key for slots in slots_from_all_venues}
+    dates = {slots.date for slots in slots_from_all_venues}
+    incoming_uids = list(uid_to_slots.keys())
+
     with Session(engine) as session:
-        # Step 1: Build set of incoming slot keys for comparison
-        incoming_keys = set()
-        for slots in slots_from_all_venues:
-            key = f"{slots.composite_key}-{slots.category}-{slots.date}-{slots.starting_time}-{slots.ending_time}"
-            incoming_keys.add(key)
-
-        # Step 2: Get unique composite_keys and dates from incoming data
-        composite_keys = {slots.composite_key for slots in slots_from_all_venues}
-        dates = {slots.date for slots in slots_from_all_venues}
-
-        # Step 3: Fetch existing slots for these composite_keys and dates from DB
-        existing_slots = session.exec(
-            select(TableForLoading).where(
-                TableForLoading.composite_key.in_(composite_keys),
-                TableForLoading.date.in_(dates)
-            )
-        ).all()
-
-        # Step 4: Identify missing slots (exist in DB but not in incoming data)
-        # and add them to the upsert list with spaces=0
-        now = datetime.now()
-        for existing in existing_slots:
-            key = f"{existing.composite_key}-{existing.category}-{existing.date}-{existing.starting_time}-{existing.ending_time}"
-            if key not in incoming_keys:
-                # This slot exists in DB but not in incoming API data - mark as unavailable
-                uid = hashlib.md5(key.encode("utf-8")).hexdigest()
-                slots_from_all_venues.append(
-                    TableForLoading(
-                        uid=uid,
-                        composite_key=existing.composite_key,
-                        category=existing.category,
-                        starting_time=existing.starting_time,
-                        ending_time=existing.ending_time,
-                        date=existing.date,
-                        price=existing.price,
-                        spaces=0,  # Mark as unavailable
-                        last_refreshed=now,
-                        booking_url=existing.booking_url
-                    )
-                )
-                logging.debug(f"Marked missing slot as unavailable: {key}")
-
-        logging.debug(f"Loading fresh data items to db: {len(slots_from_all_venues)}")
-
-        # Group slots by UID and prefer the one with available spaces (spaces > 0)
-        # This handles cases where both 40min and 60min API calls return the same slot,
-        # but one returns spaces=0 (fallback from empty response) and one returns actual availability
-        uid_to_slots = {}
-        for slots in slots_from_all_venues:
-            key = f"{slots.composite_key}-{slots.category}-{slots.date}-{slots.starting_time}-{slots.ending_time}"
-            uid = hashlib.md5(key.encode("utf-8")).hexdigest()
-
-            if uid not in uid_to_slots:
-                uid_to_slots[uid] = slots
-            else:
-                # If we already have this slot, prefer the one with available spaces
-                existing = uid_to_slots[uid]
-                if slots.spaces > 0 and existing.spaces == 0:
-                    uid_to_slots[uid] = slots
-
-        all_data = []
-        for uid, slots in uid_to_slots.items():
-            all_data.append(dict(
-                uid=uid,
-                composite_key=slots.composite_key,
-                category=slots.category,
-                starting_time=slots.starting_time,
-                ending_time=slots.ending_time,
-                date=slots.date,
-                price=slots.price,
-                spaces=slots.spaces,
-                last_refreshed=slots.last_refreshed,
-                booking_url=slots.booking_url
-            ))
-
-        if not all_data:
-            logging.warning("No data to insert after processing.")
-            return
-
-        # Step 5: create the insert
         stmt = insert(TableForLoading).values(all_data)
-
-        # Step 6: tell Postgres how to upsert
         stmt = stmt.on_conflict_do_update(
             index_elements=['uid'],
             set_={c: stmt.excluded[c] for c in all_data[0] if c != 'uid'}
         )
-
         session.exec(stmt)
+
+        # Any row already in the DB for these composite_keys/dates that wasn't just
+        # refreshed above no longer appears in the source API response — mark it
+        # unavailable rather than leaving stale availability showing.
+        mark_stale_stmt = (
+            update(TableForLoading)
+            .where(TableForLoading.composite_key.in_(composite_keys))
+            .where(TableForLoading.date.in_(dates))
+            .where(TableForLoading.spaces != 0)
+            .where(TableForLoading.uid.not_in(incoming_uids))
+            .values(spaces=0, last_refreshed=now)
+        )
+        stale_result = session.exec(mark_stale_stmt)
+
         session.commit()
-        logging.success(f"Upserted {len(all_data)} slots into {TableForLoading.__tablename__}")
+        logging.success(
+            f"Upserted {len(all_data)} slots into {TableForLoading.__tablename__} "
+            f"(marked {stale_result.rowcount} stale rows unavailable)"
+        )
 
 
 def get_all_rows(engine, table: sqlmodel.main.SQLModelMetaclass, expression: select, params=None):
@@ -305,6 +282,59 @@ def create_db_and_tables(engine):
         conn.execute(text("CREATE EXTENSION IF NOT EXISTS postgis"))
         conn.execute(text(
             "ALTER TABLE public.sportsvenue ADD COLUMN IF NOT EXISTS srid geometry(Point, 4326)"
+        ))
+        conn.commit()
+
+    ensure_starts_at_column(engine)
+    ensure_performance_indexes(engine)
+
+
+_SLOT_TABLES = ("badminton", "squash", "pickleball", "padel")
+
+
+def ensure_starts_at_column(engine):
+    """Additive-only migration — adds `starts_at` and backfills it from existing
+    date+starting_time. Safe to run repeatedly against a live DB (each statement is
+    idempotent: ADD COLUMN IF NOT EXISTS, and the backfill only touches NULL rows)."""
+    with engine.connect() as conn:
+        for table in _SLOT_TABLES:
+            conn.execute(text(f'ALTER TABLE public.{table} ADD COLUMN IF NOT EXISTS starts_at timestamp'))
+            conn.execute(text(f'''
+                UPDATE public.{table}
+                SET starts_at = (date::text || ' ' || starting_time::text)::timestamp
+                WHERE starts_at IS NULL
+            '''))
+        conn.commit()
+
+
+def ensure_performance_indexes(engine):
+    """Additive-only index migration — safe to run repeatedly against a live DB.
+
+    Every search filters `composite_key IN (...) AND date == X AND spaces > 0`, and
+    delete_past_slots() filters `date < today()`; with only the primary key (uid) to
+    go on, both were full table scans. Adds:
+      - a plain composite index (composite_key, date) per slot table — covers the
+        general composite_key/date lookups (search, delete_past_slots, the
+        insert-time stale-marking UPDATE).
+      - a partial composite index on the same columns WHERE spaces > 0 — near-free
+        given spaces > 0 is search's dominant filter; keeps the index small since
+        stale/unavailable rows (spaces = 0) are excluded from it entirely.
+      - a GiST index on sportsvenue.srid — ST_DWithin/ST_Distance in /venues/near
+        would otherwise sequential-scan as venue count grows.
+    """
+    with engine.connect() as conn:
+        for table in _SLOT_TABLES:
+            conn.execute(text(
+                f'CREATE INDEX IF NOT EXISTS ix_{table}_composite_key_date '
+                f'ON public.{table} (composite_key, date)'
+            ))
+            conn.execute(text(
+                f'CREATE INDEX IF NOT EXISTS ix_{table}_composite_key_date_active '
+                f'ON public.{table} (composite_key, date) WHERE spaces > 0'
+            ))
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_sportsvenue_srid_gist "
+            "ON public.sportsvenue USING GIST (srid)"
         ))
         conn.commit()
 
@@ -360,6 +390,7 @@ def truncate_by_composite_key_and_reload(slots_from_all_venues, TableForLoading:
                 spaces=slots.spaces,
                 last_refreshed=slots.last_refreshed,
                 booking_url=slots.booking_url,
+                starts_at=datetime.combine(slots.date, slots.starting_time),
             )
             session.add(orm_object)
 

--- a/sportscanner/storage/postgres/tables.py
+++ b/sportscanner/storage/postgres/tables.py
@@ -37,6 +37,11 @@ class BadmintonMasterTable(SQLModel, table=True):
     spaces: int
     last_refreshed: datetime
     booking_url: str | None
+    # Precomputed date+starting_time, populated at write time (see insert_records_to_table).
+    # Lets "is this slot still bookable" be a plain indexed timestamp comparison instead of
+    # a per-row to_timestamp(concat(date, starting_time)) computed at query time, which
+    # can't use an index. Nullable for rows written before this column existed.
+    starts_at: Optional[datetime] = None
 
     composite_key: str = Field(default=None, foreign_key="public.sportsvenue.composite_key")
     __tablename__ = "badminton"
@@ -56,6 +61,11 @@ class SquashMasterTable(SQLModel, table=True):
     spaces: int
     last_refreshed: datetime
     booking_url: str | None
+    # Precomputed date+starting_time, populated at write time (see insert_records_to_table).
+    # Lets "is this slot still bookable" be a plain indexed timestamp comparison instead of
+    # a per-row to_timestamp(concat(date, starting_time)) computed at query time, which
+    # can't use an index. Nullable for rows written before this column existed.
+    starts_at: Optional[datetime] = None
 
     composite_key: str = Field(default=None, foreign_key="public.sportsvenue.composite_key")
     __tablename__ = "squash"
@@ -75,6 +85,11 @@ class PickleballMasterTable(SQLModel, table=True):
     spaces: int
     last_refreshed: datetime
     booking_url: str | None
+    # Precomputed date+starting_time, populated at write time (see insert_records_to_table).
+    # Lets "is this slot still bookable" be a plain indexed timestamp comparison instead of
+    # a per-row to_timestamp(concat(date, starting_time)) computed at query time, which
+    # can't use an index. Nullable for rows written before this column existed.
+    starts_at: Optional[datetime] = None
 
     composite_key: str = Field(default=None, foreign_key="public.sportsvenue.composite_key")
     __tablename__ = "pickleball"
@@ -94,6 +109,11 @@ class PadelMasterTable(SQLModel, table=True):
     spaces: int
     last_refreshed: datetime
     booking_url: str | None
+    # Precomputed date+starting_time, populated at write time (see insert_records_to_table).
+    # Lets "is this slot still bookable" be a plain indexed timestamp comparison instead of
+    # a per-row to_timestamp(concat(date, starting_time)) computed at query time, which
+    # can't use an index. Nullable for rows written before this column existed.
+    starts_at: Optional[datetime] = None
 
     composite_key: str = Field(default=None, foreign_key="public.sportsvenue.composite_key")
     __tablename__ = "padel"

--- a/sportscanner/variables.py
+++ b/sportscanner/variables.py
@@ -29,6 +29,10 @@ class Settings(BaseSettings):
     ENV: str
     KINDE_DOMAIN: str
     KINDE_CLIENT_ID: str
+    # Valkey (Redis-protocol-compatible) cache for near-static lookups (postcode
+    # geocoding, venues-within-radius). Optional — caching is skipped entirely if unset.
+    VALKEY_URL: Optional[str] = None
+    CACHE_TTL_SECONDS: int = 300
 
     model_config = SettingsConfigDict(env_file=env_file, env_file_encoding="utf-8", extra="ignore")
 


### PR DESCRIPTION
## Summary

Response to an external code review of this repo, plus follow-up requests (Valkey caching, circuit breaker, docs).

### Security (real bugs, not narrative)
- `/health/scrapers` interpolated `sports` directly as a SQL table name and array literal. Fixed with an allow-list + bound/cast array param. Verified: injection payload now returns a clean 400.
- `/venues/near` built a correctly parameterized query, then discarded it and ran an unparameterized one instead (which also referenced a column, `geog_point`, that doesn't exist on `sportsvenue` - the real column is `srid`). The parameterized, correct version now runs.

### Database performance
- `(composite_key, date)` + partial `(composite_key, date) WHERE spaces > 0` indexes on all four slot tables, GiST on `sportsvenue.srid`. Search's dominant filter and `delete_past_slots()` were full table scans before this (verified via `EXPLAIN`, before/after). Applied to dev and prod.
- New `starts_at` column (precomputed `date` + `starting_time`), replacing a per-row `to_timestamp(concat(...))` computed at query time. Migrated + backfilled on dev and prod (0 mismatches verified against the old computed value).
- `insert_records_to_table` no longer reads existing rows into Python to diff against the incoming batch - marking stale slots is now one indexed SQL `UPDATE`. Verified idempotent across repeated real pipeline runs, all four sports, zero tracebacks.
- `search/{sport}` no longer self-calls `/venues/near` over HTTP; both share one function now.

### Caching
- Valkey, 5 min TTL, for postcode geocoding + venues-within-radius (near-static, previously recomputed every search). Best-effort - unreachable cache degrades to a miss, never an API error. Connectivity verified live.
- **Needs a manual step**: add `VALKEY_URL` + `CACHE_TTL_SECONDS` to Render's environment variables dashboard for prod (local `.env`/`.dev.env` are gitignored and don't reach Render).

### Crawler resilience
- Per-provider circuit breaker in `BaseCrawler`: after >=20 requests, if >=50% failed (connection error or 5xx - a 4xx doesn't count), remaining queued requests short-circuit and in-flight ones are cancelled. Verified against a real pipeline run (no false trip on a healthy small provider, e.g. CitySports' 6 requests) and a synthetic dead-provider test (stopped at exactly 20/200, cancelled the rest, ~0.6s instead of the full budget).

### Docs
- `docs/database.md`, `docs/crawlers.md`, `docs/api.md`, top-level `ARCHITECTURE.md` - each with a Mermaid diagram (rendered and validated locally via mermaid-cli). README trimmed to a crisp overview linking out. `CLAUDE.md` gets a documentation style rule (no em dashes, no emojis) and the stale staging-table/`swap_tables()` references are corrected to describe the real write path.

### Not done (deliberately - needs your call, not a code change)
- Docker image split (the API image ships Playwright/Chromium it never uses - only `towerhamlets/core/authenticate.py` needs it). This needs a new image/tag coordinated with Render's deploy config, which I don't have access to. Flagged, not attempted.

## Verification
- All four pipelines (`badminton`/`squash`/`pickleball`/`padel`) run end-to-end against dev DB with the new write path: zero tracebacks, correct upsert + stale-marking counts (e.g. padel correctly marked 486 stale rows in one run).
- Full API test pass via `TestClient`: injection rejected (400), health/venues/search all return correct data, invalid postcode returns a clean 400 instead of a 500.
- `EXPLAIN` confirms the new indexes are actually used by the planner (bitmap index scan, not sequential scan).
- Migrations (indexes + `starts_at` backfill) already applied to both dev and prod - this PR is code catching up to state that's already live, not a migration still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)