### PR TITLE
Fix N+1 query in search result formatting (33x speedup)

### DIFF
--- a/sportscanner/storage/postgres/dataset_transform.py
+++ b/sportscanner/storage/postgres/dataset_transform.py
@@ -53,6 +53,11 @@ def sort_and_format_grouped_slots_for_ui(
         grouped_slots, distance_from_venues_reference
         ) -> List[dict]:
     processed_slots: List = []
+    # Was called once per group inside the loop below: a full `SELECT * FROM
+    # sportsvenue` re-run for every distinct (venue, date) result, dominating
+    # search latency (29 groups -> 29 redundant full-table round trips). Venue
+    # metadata doesn't change per-group, so look it up once per call.
+    lookup_dict = generate_venue_lookup()
     for groups in grouped_slots:
         # Sort the groups based on 'date' and 'starting_time'
         sorted_slots_in_group = sorted(
@@ -87,7 +92,6 @@ def sort_and_format_grouped_slots_for_ui(
             )
 
         # Populating metadata from venues into main availability items
-        lookup_dict = generate_venue_lookup()
         lookup_data = lookup_dict.get(earliest_slot_in_group.composite_key, None)
 
         now_uk = datetime.now(ZoneInfo("Europe/London"))


### PR DESCRIPTION
## What this answers

You asked why searches weren't getting visibly faster after the Valkey caching work. Two separate things were going on, and I measured both directly rather than guessing:

### 1. The caching IS working
Isolated `get_venues_near_postcode` directly: **2.387s cold** (real postcodes.io + PostGIS call) → **0.190s**, then **0.068s** on repeat calls (12-35x faster). It just wasn't visible in the log line you were watching (`Time taken for retrieval, transformations, sorting` in `search/endpoints.py`) — that timer starts *after* the venues/near call already completed, so the caching benefit is structurally invisible there.

### 2. A much bigger, unrelated bug was swamping it
`generate_venue_lookup()` (a full `SELECT * FROM sportsvenue`, ~0.6s per call against the hosted DB) was being called **once per result group**, inside the formatting loop, instead of once per request. A typical 5-10 mile radius search returns ~29 distinct (venue, date) groups, so this was **29 redundant full-table queries per search**.

Measured: **8.64s → 0.26s** for the same 29-group result after hoisting the lookup out of the loop (33x). This cost had nothing to do with cache warmth, so it explains why total latency looked "similar" regardless of whether the venues/near cache was hit or missed: this dominated everything.

## Fix
One function, `sort_and_format_grouped_slots_for_ui` in `dataset_transform.py`: `generate_venue_lookup()` moved from inside the per-group loop to once at the top of the function. No public signature change; only two callers (`search/endpoints.py`, `mcp/tools/search.py`), both unaffected.

## Verification
- Full `/search/{sport}` request: **2.675s cold-cache / ~0.76-0.8s warm-cache** (previously would have been ~8-10s+ regardless of cache state).
- Tested badminton, squash, padel via `TestClient` — correct results, venue metadata populated, unchanged output shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)