### PR TITLE
Log explicit cache HIT/MISS/SET for observability

### DIFF
--- a/sportscanner/cache.py
+++ b/sportscanner/cache.py
@@ -46,13 +46,22 @@ def _get_client():
 
 
 def cache_get_json(key: str) -> Optional[Any]:
-    """Returns the cached value for `key`, or None on a miss/any cache failure."""
+    """Returns the cached value for `key`, or None on a miss/any cache failure.
+
+    Logs an explicit HIT/MISS at INFO so cache behaviour is directly visible in
+    logs instead of having to be inferred from request timing (which stops being
+    a reliable signal once the cache is warm and everything is already fast).
+    """
     client = _get_client()
     if client is None:
         return None
     try:
         raw = client.get(key)
-        return json.loads(raw) if raw is not None else None
+        if raw is not None:
+            logging.info(f"Cache HIT: {key}")
+            return json.loads(raw)
+        logging.info(f"Cache MISS: {key}")
+        return None
     except Exception as e:
         logging.warning(f"Cache GET failed for key={key}: {e}")
         return None
@@ -64,6 +73,8 @@ def cache_set_json(key: str, value: Any, ttl_seconds: Optional[int] = None) -> N
     if client is None:
         return
     try:
-        client.set(key, json.dumps(value), ex=ttl_seconds or settings.CACHE_TTL_SECONDS)
+        ttl = ttl_seconds or settings.CACHE_TTL_SECONDS
+        client.set(key, json.dumps(value), ex=ttl)
+        logging.info(f"Cache SET: {key} (ttl={ttl}s)")
     except Exception as e:
         logging.warning(f"Cache SET failed for key={key}: {e}")


### PR DESCRIPTION
Prompted by "I can't tell if caching is being used or not" — timing alone isn't a reliable signal once the N+1 fix + indexes already make everything fast; there's no visible cliff to eyeball anymore. Adds an explicit `Cache HIT: {key}` / `Cache MISS: {key}` / `Cache SET: {key} (ttl=300s)` log line at INFO so this is directly greppable in Render logs, not inferred.

Verified locally: repeat lookup for the same postcode/radius shows MISS -> MISS -> SET -> SET -> HIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)